### PR TITLE
Update .gitignore to exclude Original_docs directory; enhance GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/src/Original_docs/*
+./src/Original_docs
+./src/Original_docs/*

--- a/docs/server-staff-handbook/moderator/github-records.md
+++ b/docs/server-staff-handbook/moderator/github-records.md
@@ -6,8 +6,15 @@ title: GitHub Records
 import CardGrid, { Card } from "@site/src/components/CardGrid";
 import RoleBadge from "@site/src/components/RoleBadge";
 import GitHubLogCard from "@site/src/components/GitHubLogCard";
+import TextWithButton from "@site/src/components/TextWithButton";
 
 # GitHub Records (Moderators Only)
+
+<TextWithButton
+  text="Open the GitHub Warning Book to create/update member logs."
+  buttonLabel="Open Warning Book"
+  buttonHref="https://github.com/users/lolmaxz/projects/3"
+/>
 
 All moderation actions must be recorded in the **GitHub Warning Book** to keep history consistent and searchable.
 
@@ -27,6 +34,7 @@ Clear records help us make fair decisions, see patterns, and coordinate as a tea
   <Card title="Access" status="info" icon="🔑">
     <ul>
       <li>Open the GitHub Warning Book (linked in the <strong>mod-special</strong> channel).</li>
+      <li>Direct link: <a href="https://github.com/users/lolmaxz/projects/3" target="_blank" rel="noopener noreferrer">GitHub Warning Book</a></li>
       <li>Make sure you are signed in with the correct account.</li>
     </ul>
   </Card>
@@ -74,12 +82,6 @@ Clear records help us make fair decisions, see patterns, and coordinate as a tea
 ## Logging Template
 
 Copy and paste this into the GitHub issue body, then replace the bracketed fields:
-
-:::info Card Title Format
-The card title must be formatted as:
-<strong>DiscordTag [DiscordID]</strong>
-Example: <code>FictionalUser [123456789012345678]</code>
-:::
 
 ```
 When: [YYYY-MM-DD HH:mm TZ]


### PR DESCRIPTION
Update .gitignore to exclude Original_docs directory; enhance GitHub Records documentation with a new button component and direct link to the GitHub Warning Book for improved accessibility.

---

This pull request updates the moderator documentation for GitHub records to make it easier for staff to access and use the GitHub Warning Book. The changes improve visibility and accessibility of the Warning Book by adding a direct link and a new UI element, and remove redundant formatting instructions.

**Improvements to accessibility and workflow:**
* Added a `TextWithButton` component at the top of the page with a direct link to the GitHub Warning Book, making it easier for moderators to create or update member logs.
* Added a direct link to the GitHub Warning Book in the "Access" card section for quick reference.

**Documentation cleanup:**
* Removed the "Card Title Format" info box to streamline instructions and reduce redundancy.