### PR TITLE
Update .gitignore to include specific Original_docs files; modify doc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ yarn-error.log*
 /src/Original_docs/*
 ./src/Original_docs
 ./src/Original_docs/*
+Original_docs/Official Eden Apis Event Team Handbook V4 (Read Only Version).md
+Original_docs/The Eden Apis General Handbook V1 (Read Only Version).md
+Original_docs/The Eden Apis Staff Handbook V1 (Read Only Version).md

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,10 +10,11 @@ const config: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://staff-handbooks.vercel.app/",
+  url: "https://theedenapis.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/",
+  baseUrl: "/staff-handbooks/",
+  trailingSlash: false,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Update .gitignore to include specific Original_docs files; modify docusaurus.config.ts to change the site URL and base path for improved deployment structure.

This pull request updates the deployment configuration for the Docusaurus site, mainly to point to a new production URL and adjust the base path settings.

Deployment configuration updates:

* Changed the production `url` in `docusaurus.config.ts` from `https://staff-handbooks.vercel.app/` to `https://theedenapis.com`.
* Set the `baseUrl` to `/staff-handbooks/` and added `trailingSlash: false` to support the new deployment path structure.