### PR TITLE
Update staff documentation to reflect channel name changes: replaced old names with new ones and removed moderators's usernames.

### DIFF
--- a/docs/general-handbook/server-votes-explained.md
+++ b/docs/general-handbook/server-votes-explained.md
@@ -36,10 +36,10 @@ Participate actively in votes relevant to your role to contribute to the server'
 
 ---
 
-### Moderator Promotions in 📙moderator-only
+### Moderator Promotions in 📙moderators
 
 - For <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> to discuss promotion of any <RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color="#38c8e8" /> to Moderator.
-- Promotion votes will be initiated in a new thread in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> upon a Cutie Helper completing all parts of Moderator training by <RoleBadge role="Server Committee" badgeIcon="server_committee_role_icon.webp" color="#db1cb8" />, typically started by <RoleBadge role="Head Moderator 🔰" badgeIcon="" color="#db1cb8" />.
+- Promotion votes will be initiated in a new thread in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> upon a Cutie Helper completing all parts of Moderator training by <RoleBadge role="Server Committee" badgeIcon="server_committee_role_icon.webp" color="#db1cb8" />, typically started by <RoleBadge role="Head Moderator 🔰" badgeIcon="" color="#db1cb8" />.
 - Promotion vote will pass upon 80% of voting Moderators to be in agreement that a Cutie Helper is ready to be a Moderator.
 - <RoleBadge role="Head Moderator 🔰" badgeIcon="" color="#db1cb8" /> will finalize the vote.
 
@@ -54,9 +54,9 @@ Participate actively in votes relevant to your role to contribute to the server'
 
 ---
 
-### Moderator discussion votes in 📙moderator-only
+### Moderator discussion votes in 📙moderators
 
-- <Tooltip tip="Used by Moderators to discuss rule violation punishments, server ban votes, or media acceptable to remain within the server." bubbleColor="#d255ec" labelColor="#e68027"> Moderator Discussion Thread and Votes</Tooltip> can be initiated by any <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> within <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
+- <Tooltip tip="Used by Moderators to discuss rule violation punishments, server ban votes, or media acceptable to remain within the server." bubbleColor="#d255ec" labelColor="#e68027"> Moderator Discussion Thread and Votes</Tooltip> can be initiated by any <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> within <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
 - Any <RoleBadge role="Committee Member"  color="#db1cb8" /> is allowed to provide inputs to assist Moderators in discussions about a community member but may only vote within their respective team.
 - Rule violation punishment and media acceptability votes will pass with greater than 50% voting Moderators in agreement.
 - <Tooltip tip="Server Ban votes require **24hrs** to be reviewed by all Moderators before being finalized, typically a Server Committee member will finalize the vote." bubbleColor="#d255ec" labelColor="#e68027"> Server Ban Votes </Tooltip> will pass with greater then 80% voting Moderators in agreement.

--- a/docs/general-handbook/staff-channels.md
+++ b/docs/general-handbook/staff-channels.md
@@ -42,7 +42,7 @@ Now, here's all the Channels you need to Familiarize yourself with
 - <ChannelBadge label="⭕server-chat-reports" link="https://discord.com/channels/734595073920204940/996504897476366497" />: This channel is used to report anything you may see in chat that may or could violate our server's rules.
 <details>
   <summary>Important Note about <ChannelBadge label="⭕server-chat-reports" link="https://discord.com/channels/734595073920204940/996504897476366497" /></summary>
-    <p>- Cutie helpers and moderators may report things directly in <ChannelBadge label="📗helper-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789" /> or <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474" /> instead of using this channel.<br/>
+    <p>- Cutie helpers and moderators may report things directly in <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789" /> or <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474" /> instead of using this channel.<br/>
     Simply provide the message link to the problematic post and explain why you think it needed to be reported. The server team will handle the rest. <br/>
     If you are unsure if something should be reported, it is always better to report it and let the server team decide if it needs to be addressed. <br/>
     ANY staff member can report a message, but only server staff can handle the reports. This is just a faster direct line of communication for staff to report messages.</p>

--- a/docs/general-handbook/staff-roles/server-positions/server-roles.md
+++ b/docs/general-handbook/staff-roles/server-positions/server-roles.md
@@ -116,7 +116,7 @@ Being anonymous helps Chat Moderators observe the server chat without having any
 The following channel changes have been implemented:
 
 - **helper-chat** → **verification-chat** - Dedicated channel for discussing **verification tickets only**
-- **moderator-only** - Now opened up for Cutie Helpers as soon as they get onboarded for transparency and easier training. Use this channel for all questions, issues, and discussions not related to verification tickets.
+- **moderators** - Now opened up for Cutie Helpers as soon as they get onboarded for transparency and easier training. Use this channel for all questions, issues, and discussions not related to verification tickets.
 :::
 
 ---

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -64,7 +64,7 @@ Please refer to the specific handbook that corresponds to your role or area of i
 - <ChannelBadge variant="post" label="🎉staff-projects" link="https://discord.com/channels/734595073920204940/1024400360229589112" /> - Propose new ideas and changes
 - <ChannelBadge variant="post" label="💾staff-documents" link="https://discord.com/channels/734595073920204940/1007807458409984010" /> - Staff-related documents and resources
 - <ChannelBadge variant="post" label="📘events-organization" link="https://discord.com/channels/734595073920204940/741166096421486645" /> - Event planning and coordination
-- <ChannelBadge label="📗helper-chat" link="https://discord.com/channels/734595073920204940/737215117049069610" /> - Chat for helpers and moderators
+- <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/737215117049069610" /> - Chat for helpers and moderators
 
 ### New Staff Onboarding 🚀
 

--- a/docs/server-staff-handbook/ban-votes/ban-types-overview.md
+++ b/docs/server-staff-handbook/ban-votes/ban-types-overview.md
@@ -16,7 +16,7 @@ This section outlines the different types of ban procedures available to staff m
 
 **Who**: <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> only  
 **Duration**: 24 hours  
-**Location**: <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>
+**Location**: <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>
 
 - Standard ban votes for rule violations
 - Requires discussion and voting among all moderators

--- a/docs/server-staff-handbook/ban-votes/ban-votes-for-members.md
+++ b/docs/server-staff-handbook/ban-votes/ban-votes-for-members.md
@@ -10,13 +10,13 @@ import DiscordConversation, { DiscordMessage } from "@site/src/components/Discor
 # Ban Votes for Members (Moderators Only)
 
 :::warning
-All ban votes are held in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> and last **24 hours**.
+All ban votes are held in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> and last **24 hours**.
 :::
 
 ## Initiating a Ban Vote
 
 - Any <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> can initiate a ban vote in accordance with the **Server Guidelines**
-- Create a **thread** in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> to discuss:
+- Create a **thread** in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> to discuss:
   - The rule(s) broken
   - Why the member deserves a ban
 

--- a/docs/server-staff-handbook/chat-moderation/chat-moderation-overview.md
+++ b/docs/server-staff-handbook/chat-moderation/chat-moderation-overview.md
@@ -20,7 +20,7 @@ This section covers the chat moderation responsibilities and procedures for diff
     <ul>
       <li><strong>Primary Focus:</strong> Simple rule reminders and small disruptions</li>
       <li><strong>Tools:</strong> Templates, polite corrections, screenshotting</li>
-      <li><strong>Escalation:</strong> Report to <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/></li>
+      <li><strong>Escalation:</strong> Report to <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/></li>
     </ul>
     <p><strong>⚠️ Restrictions:</strong> Cannot issue warnings, mutes, bans, or make final decisions</p>
   </Card>
@@ -30,7 +30,7 @@ This section covers the chat moderation responsibilities and procedures for diff
     <ul>
       <li><strong>Primary Focus:</strong> De-escalation and formal moderation</li>
       <li><strong>Tools:</strong> Timeouts, channel cleanup, formal warnings</li>
-      <li><strong>Escalation:</strong> Consult in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/></li>
+      <li><strong>Escalation:</strong> Consult in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/></li>
     </ul>
     <p><strong>Additional:</strong> Train and assist Cutie Helpers</p>
   </Card>
@@ -68,6 +68,6 @@ When in doubt, consult with other staff members before taking action. Cutie Help
 
 - Allowing Cutie Helpers to participate in tickets as **observers**
 - Providing guidance on proper procedures
-- Answering questions in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> (use <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> for verification ticket discussions only)
+- Answering questions in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> (use <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> for verification ticket discussions only)
 
 For detailed procedures, see the specific role pages in this section.

--- a/docs/server-staff-handbook/chat-moderation/cutie-helper-chat-moderation.md
+++ b/docs/server-staff-handbook/chat-moderation/cutie-helper-chat-moderation.md
@@ -14,7 +14,7 @@ As a <RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color
 :::danger Important Restrictions
 Cutie Helpers do **not** issue warnings, mutes, bans, or make final decisions. These tasks are for <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> only.
 
-If you encounter a situation requiring these actions, **report it to a Moderator** in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
+If you encounter a situation requiring these actions, **report it to a Moderator** in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
 :::
 
 ## Your Responsibilities
@@ -41,7 +41,7 @@ Not everything in chat requires escalating to a ticket. As a <RoleBadge role="Cu
 
   - Capture evidence of any rule violations.
   - Delete messages that violate server rules (e.g., inappropriate images).
-  - After deletion, please post your screenshot(s) in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> so the mod team can more easily keep track of your work.
+  - After deletion, please post your screenshot(s) in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> so the mod team can more easily keep track of your work.
 
 :::note
 Always remain professional and courteous when interacting with members.

--- a/docs/server-staff-handbook/chat-moderation/moderator-chat-moderation.md
+++ b/docs/server-staff-handbook/chat-moderation/moderator-chat-moderation.md
@@ -34,7 +34,7 @@ As a <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68
 
 - **Collaboration**:
 
-  - If unsure, consult with other <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
+  - If unsure, consult with other <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
   - Include message links when asking for assistance.
 
 :::warning

--- a/docs/server-staff-handbook/moderator/mod-on-call.md
+++ b/docs/server-staff-handbook/moderator/mod-on-call.md
@@ -16,7 +16,7 @@ The **Mod on Call** is the <RoleBadge role="Moderator" badgeIcon="moderator_role
 - One <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> is assigned each week as the **Mod on Call**.
 - Responsibility rotates through the Moderator team in a **fixed order**.
 - The schedule is tracked via a **Google Sheet** so each Moderator knows when they are expected to handle ticket logging.
-- A smaller extraction from the full schedule is pinned in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
+- A smaller extraction from the full schedule is pinned in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
 
 ## Schedule Swaps
 
@@ -38,19 +38,17 @@ The Mod on Call for the week is responsible for:
 For instructions on how to log tickets to the GitHub Warning Book, see the [GitHub Records](./github-records) page.
 :::
 
-
-
 ## Example Schedule
 
-| Week | Date Start   | Date End     | Moderator       | Notes |
-|------|--------------|--------------|-----------------|-------|
-| 47   | November 22  | November 28  | MoonPennyBunny  |       |
-| 48   | November 29  | December 5   | Krenki          |       |
-| 49   | December 6   | December 12  | Echo            |       |
-| 50   | December 13  | December 19  | SoliiCannoli    |       |
-| 51   | December 20  | December 26  | PrionIron       |       |
-| 52   | December 27  | January 2    | Alicendrome     |       |
+| Week | Date Start  | Date End    | Moderator    | Notes |
+| ---- | ----------- | ----------- | ------------ | ----- |
+| 47   | November 22 | November 28 | Moderator #1 |       |
+| 48   | November 29 | December 5  | Moderator #2 | LOA   |
+| 49   | December 6  | December 12 | Moderator #3 |       |
+| 50   | December 13 | December 19 | Moderator #4 | SICK  |
+| 51   | December 20 | December 26 | Moderator #5 |       |
+| 52   | December 27 | January 2   | Moderator #6 |       |
 
 :::tip Check the Schedule
-Always check the pinned Google Sheet in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> to know when your week is coming up!
+Always check the pinned Google Sheet in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> to know when your week is coming up!
 :::

--- a/docs/server-staff-handbook/moderator/moderators-only.md
+++ b/docs/server-staff-handbook/moderator/moderators-only.md
@@ -46,8 +46,8 @@ These pages are for <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.p
 
 - **[Ban Votes for Members](../ban-votes/ban-votes-for-members)** - Initiate and manage ban votes
 - **[Chat Moderation](../chat-moderation/moderator-chat-moderation)** - De-escalation and formal moderation procedures
-- **[Server Channels](../server-channels)** - Access to <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474" /> and other moderator channels
+- **[Server Channels](../server-channels)** - Access to <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474" /> and other moderator channels
 
 :::tip Collaboration
-Always consult with other moderators in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474" /> when you need guidance or are unsure about a situation.
+Always consult with other moderators in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474" /> when you need guidance or are unsure about a situation.
 :::

--- a/docs/server-staff-handbook/moderator/staff-talk-tickets.md
+++ b/docs/server-staff-handbook/moderator/staff-talk-tickets.md
@@ -20,7 +20,7 @@ Cutie Helpers may observe these tickets as part of their training but cannot iss
 :::
 
 :::info
-**For the first 2 months** as a <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" />, draft your messages in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474" /> and get approval from a <RoleBadge role="Server Committee Member" badgeIcon="server_committee_role_icon.webp" color="#db1cb8" /> before opening tickets.
+**For the first 2 months** as a <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" />, draft your messages in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474" /> and get approval from a <RoleBadge role="Server Committee Member" badgeIcon="server_committee_role_icon.webp" color="#db1cb8" /> before opening tickets.
 :::
 
 ## Important Guidelines
@@ -140,7 +140,7 @@ Use a calm, professional tone. Keep messages short, clear, and focused on facts.
 - Explain the outcome and next steps
 - Thank them for their time and confirm understanding
 
-If it becomes too much to handle, request help from another <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
+If it becomes too much to handle, request help from another <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
 :::warning Don't Stress!
 Remain calm and objective! If you feel yourself getting frustrated, please step away and ask for help.
 :::
@@ -192,7 +192,7 @@ Remain calm and objective! If you feel yourself getting frustrated, please step 
 
 **Do not remove the member before they have acknowledged the punishment.** We need explicit acknowledgement to confirm they read and understood the rule break and the action taken.
 
-While waiting for acknowledgement, **ping the member every ~24 hours** to bring the ticket back to their attention. If they remain unresponsive for <u>two weeks</u> (or are clearly active elsewhere while ignoring the ticket), you may request to **temporarily remove their verification until they respond** in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> by adding back the <RoleBadge role="Unverified Role" badgeIcon="unverified_role_icon.png" color="#de0000" />.
+While waiting for acknowledgement, **ping the member every ~24 hours** to bring the ticket back to their attention. If they remain unresponsive for <u>two weeks</u> (or are clearly active elsewhere while ignoring the ticket), you may request to **temporarily remove their verification until they respond** in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> by adding back the <RoleBadge role="Unverified Role" badgeIcon="unverified_role_icon.png" color="#de0000" />.
 
 If this still does not work, the <RoleBadge role="Head Moderator" color="#e68027" /> may decide to close the ticket and log it as "unresponsive".
 :::
@@ -221,5 +221,5 @@ As a <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68
 
 - Allow Cutie Helpers to **observe** the ticket process
 - Explain your reasoning and approach
-- Answer their questions in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>
+- Answer their questions in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>
 - Remember: they cannot issue punishments themselves, but learning by observation is valuable

--- a/docs/server-staff-handbook/onboarding/cutie-helper-training.md
+++ b/docs/server-staff-handbook/onboarding/cutie-helper-training.md
@@ -21,7 +21,7 @@ This page outlines the training expectations, restrictions, and promotion path f
     <li>Issue bans</li>
     <li>Make final moderation decisions</li>
   </ul>
-  <p>These tasks are for <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> only. If you encounter a situation requiring these actions, report it in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.</p>
+  <p>These tasks are for <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> only. If you encounter a situation requiring these actions, report it in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.</p>
 </Card>
 
 ---
@@ -52,10 +52,10 @@ All <RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color=
 
 - **Shadow Moderators** to learn proper workflow and procedures
 - **Observe tickets** to understand how issues are resolved
-- **Ask questions** in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> — Moderators are expected to help train you!
+- **Ask questions** in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> — Moderators are expected to help train you!
 
 :::tip Use Verification-Chat Correctly
-<ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> is for **verification ticket discussions only**. All other questions, issues, and discussions should go to <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
+<ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> is for **verification ticket discussions only**. All other questions, issues, and discussions should go to <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
 :::
 
 ---

--- a/docs/server-staff-handbook/onboarding/onboarding.md
+++ b/docs/server-staff-handbook/onboarding/onboarding.md
@@ -16,9 +16,9 @@ import { Settings } from 'lucide-react';
 Welcome to the Eden Apis staff team! This comprehensive guide will help you understand your role, responsibilities, and the tools available to you.
 
 ::::info Getting Started
-Take your time to familiarize yourself with all sections. Don't hesitate to ask questions in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
+Take your time to familiarize yourself with all sections. Don't hesitate to ask questions in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>.
 
-**Note:** As a <RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color="#38c8e8" />, you will have access to <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> for transparency and easier training. Use <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> **only** for verification ticket discussions.
+**Note:** As a <RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color="#38c8e8" />, you will have access to <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> for transparency and easier training. Use <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> **only** for verification ticket discussions.
 ::::
 
 ## First-Day Quick Start
@@ -93,7 +93,7 @@ For detailed information about the training process, requirements, and promotion
   <Card title="Communication" status="info">
     <ul>
       <li><ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> - Verification tickets <strong>only</strong></li>
-      <li><ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> - All questions, discussions, and issues</li>
+      <li><ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> - All questions, discussions, and issues</li>
       <li><ChannelBadge label="🎫open-a-ticket" link="https://discord.com/channels/734595073920204940/1106413750975746070"/></li>
     </ul>
   </Card>
@@ -226,7 +226,7 @@ Three types of ban votes based on severity:
   <p><strong>Notes:</strong></p>
   <ul>
     <li><code>/rename</code> has a brief cooldown. If it fails, you can edit the ticket thread title manually.</li>
-    <li><RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color="#38c8e8" /> may ask a <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474" /> to assist with renaming.</li>
+    <li><RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color="#38c8e8" /> may ask a <RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" /> in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474" /> to assist with renaming.</li>
   </ul>
 </Card>
 
@@ -254,7 +254,7 @@ Three types of ban votes based on severity:
 ### When You Need Assistance
 
 1. **Verification Ticket Discussions**: Ask in <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/1234567890123456789"/> _(verification only)_
-2. **All Other Questions & Issues**: Consult in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/>
+2. **All Other Questions & Issues**: Consult in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/>
 3. **Technical Problems**: Ping <RoleBadge role="lolmaxz" color="#ff6b6b" /> for bot/linking issues
 4. **Staff-Talk Tickets**: Use <ChannelBadge label="🎫open-a-ticket" link="https://discord.com/channels/734595073920204940/1106413750975746070"/> → <DiscordButton type="link" emoji="☎️" href="./moderator/staff-talk-tickets">Talk to a Staff</DiscordButton> _(Moderators only)_
 

--- a/docs/server-staff-handbook/server-channels.md
+++ b/docs/server-staff-handbook/server-channels.md
@@ -16,9 +16,9 @@ Once your application to be part of the server staff has been accepted, you will
 
 ## Text Channels
 
-- <ChannelBadge label="📗helper-chat" link="https://discord.com/channels/734595073920204940/737215117049069610" />: This channel is where new server staff begins and where they report things they see on the server or any issues with a verification ticket. It's the main channel for moderators to become.
+- <ChannelBadge label="💬verification-chat" link="https://discord.com/channels/734595073920204940/737215117049069610" />: This channel is where new server staff begins and where they report things they see on the server or any issues with a verification ticket. It's the main channel for moderators to become.
 
-- <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474" />: This channel is where moderators (those who got promoted from cutie helper to moderator) discuss any issues on the server, from trouble makers, rule violation handlings to helping out with verification as well and some discussions about bans and other moderative actions.
+- <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474" />: This channel is where moderators (those who got promoted from cutie helper to moderator) discuss any issues on the server, from trouble makers, rule violation handlings to helping out with verification as well and some discussions about bans and other moderative actions.
 
 - <ChannelBadge label="🟩-kicks-bans-logs" link="https://discord.com/channels/734595073920204940/781628317925244978" />: This is where most of the ban and kick commands are executed, so we can keep a clean channel only for the kicks and bans. It's easier to find back a ban or a kick. Both helpers and moderators can access this channel.
 

--- a/docs/server-staff-handbook/server-rule-violations.md
+++ b/docs/server-staff-handbook/server-rule-violations.md
@@ -28,7 +28,7 @@ When a member breaks a server rule, follow these steps to ensure proper handling
 
 <CardGrid columns={2}>
   <Card title={<><RoleBadge role="Cutie Helper" badgeIcon="cutie_helper_role_icon.png" color="#38c8e8" /> (Trainee)</>} status="info">
-    <p><strong>📍 Report to:</strong> <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/></p>
+    <p><strong>📍 Report to:</strong> <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/></p>
     <p><strong>Responsibilities:</strong></p>
     <ul>
       <li>Document violations (screenshot, delete, report)</li>
@@ -44,7 +44,7 @@ When a member breaks a server rule, follow these steps to ensure proper handling
 
 <Card title={<RoleBadge role="Moderator" badgeIcon="moderator_role_icon.png" color="#e68027" />} status="success">
 
-<p><strong>📍 Report to:</strong> <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/></p>
+<p><strong>📍 Report to:</strong> <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/></p>
 <p><strong>Responsibilities:</strong></p>
 <ul>
 <li>All Cutie Helper responsibilities, plus:</li>
@@ -183,9 +183,9 @@ When a member reports an issue in a ticket:
 After documentation and reporting:
 
 <Checklist checklistId="moderation-process" title="Moderation Process Checklist">
-  <Checklist.Item id="review-report"><strong>1. Moderator reviews</strong> the report in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/></Checklist.Item>
+  <Checklist.Item id="review-report"><strong>1. Moderator reviews</strong> the report in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/></Checklist.Item>
   <Checklist.Item id="open-ticket"><strong>2. Moderator opens</strong> a Staff-Talk ticket for formal action (if warranted)</Checklist.Item>
-  <Checklist.Item id="discuss-punishment"><strong>3. Moderators discuss</strong> appropriate punishment in <ChannelBadge label="📙moderator-only" link="https://discord.com/channels/734595073920204940/943466763314663474"/> following the <Tooltip tip="The Server Guidelines are currently under rework and may not be accessible to the public in the near future, as it is a sensitive document and we want to avoid people using it to circumvent rules">Server Guidelines</Tooltip></Checklist.Item>
+  <Checklist.Item id="discuss-punishment"><strong>3. Moderators discuss</strong> appropriate punishment in <ChannelBadge label="📙moderators" link="https://discord.com/channels/734595073920204940/943466763314663474"/> following the <Tooltip tip="The Server Guidelines are currently under rework and may not be accessible to the public in the near future, as it is a sensitive document and we want to avoid people using it to circumvent rules">Server Guidelines</Tooltip></Checklist.Item>
   <Checklist.Item id="log-action"><strong>4. Moderator logs</strong> the action to GitHub Warning Book</Checklist.Item>
 </Checklist>
 


### PR DESCRIPTION
Update staff documentation to reflect channel name changes: replaced instances of "helper-chat" with "verification-chat" and "moderator-only" with "moderators" across multiple files for clarity and consistency in communication protocols.

---

This pull request updates internal documentation to reflect a recent renaming of key staff channels, ensuring consistency and clarity across all staff handbooks and guides. The main change is the replacement of references to `helper-chat` and `moderator-only` channels with `verification-chat` and `moderators`, respectively. This aligns the documentation with current channel names and access policies, improving onboarding and reducing confusion for staff.

**Channel name updates across documentation:**

* All references to the `📗helper-chat` channel have been updated to `💬verification-chat` to clarify its purpose as the dedicated space for verification ticket discussions. [[1]](diffhunk://#diff-22760d417a52c66f14bee182587d458d0737a616dd14cb09748b4c725fc5809fL67-R67) [[2]](diffhunk://#diff-7f5ad49a00e8c74e54eded21ce347c380617c03a1d0336ef23f6c9626a07c380L45-R45) [[3]](diffhunk://#diff-48cd6a0bda2d153180d11194de38c3ac7b0d2899bb7b83595a8b5e21d76e56ffL119-R119)
* All references to the `📙moderator-only` channel have been changed to `📙moderators`, reflecting the updated channel name and its broader access for Cutie Helpers and Moderators. [[1]](diffhunk://#diff-334e9d814dae656bf5f9d534e2bc67f9062d97d8cd7213859a500be642ab5469L39-R42) [[2]](diffhunk://#diff-334e9d814dae656bf5f9d534e2bc67f9062d97d8cd7213859a500be642ab5469L57-R59) [[3]](diffhunk://#diff-2ef95d5acf866af3b6c2ff278faca102d76324cfb786fbbcfa93440994108dbfL19-R19) [[4]](diffhunk://#diff-e0719a55635c9858f2a35dbb308237749f145c70271d090bbc2ee449157993bbL13-R19) [[5]](diffhunk://#diff-143eeff66b420b9f379e539d8875ae111b60a217dad34060d613440d9a8c105cL23-R23) [[6]](diffhunk://#diff-143eeff66b420b9f379e539d8875ae111b60a217dad34060d613440d9a8c105cL33-R33) [[7]](diffhunk://#diff-143eeff66b420b9f379e539d8875ae111b60a217dad34060d613440d9a8c105cL71-R71) [[8]](diffhunk://#diff-3c6ca6a06ee8b2e7e1bbe7614deb46dcb6ea7a7f7e4972afc69ec6ba3f275806L17-R17) [[9]](diffhunk://#diff-3c6ca6a06ee8b2e7e1bbe7614deb46dcb6ea7a7f7e4972afc69ec6ba3f275806L44-R44) [[10]](diffhunk://#diff-1a1b66774645babd3039054282a2831832f86787df7d41ef513e6a221577cd57L37-R37) [[11]](diffhunk://#diff-7928bfd96161ed25071c9c16e283f7f1994831d5a07df9888f75dc77d55b14beL19-R19) [[12]](diffhunk://#diff-7928bfd96161ed25071c9c16e283f7f1994831d5a07df9888f75dc77d55b14beL41-R53) [[13]](diffhunk://#diff-d0a92f4d9c5e8aa3ddf434b09d73be53a83f7cadd9462e4cd584f932675e5c2dL49-R52) [[14]](diffhunk://#diff-8a9e0c3cdf0fa818e3847faa6564282e952234d18aa1e8500d0565c0b1e66af6L23-R23) [[15]](diffhunk://#diff-8a9e0c3cdf0fa818e3847faa6564282e952234d18aa1e8500d0565c0b1e66af6L143-R143) [[16]](diffhunk://#diff-8a9e0c3cdf0fa818e3847faa6564282e952234d18aa1e8500d0565c0b1e66af6L195-R195)

**Handbook and process clarifications:**

* Moderator promotion and discussion vote procedures now reference the correct `📙moderators` channel, ensuring staff follow the right communication protocols. [[1]](diffhunk://#diff-334e9d814dae656bf5f9d534e2bc67f9062d97d8cd7213859a500be642ab5469L39-R42) [[2]](diffhunk://#diff-334e9d814dae656bf5f9d534e2bc67f9062d97d8cd7213859a500be642ab5469L57-R59)
* All escalation, reporting, and collaboration instructions for Cutie Helpers and Moderators now point to the updated channels, reducing ambiguity for new and existing staff. [[1]](diffhunk://#diff-143eeff66b420b9f379e539d8875ae111b60a217dad34060d613440d9a8c105cL23-R23) [[2]](diffhunk://#diff-143eeff66b420b9f379e539d8875ae111b60a217dad34060d613440d9a8c105cL33-R33) [[3]](diffhunk://#diff-143eeff66b420b9f379e539d8875ae111b60a217dad34060d613440d9a8c105cL71-R71) [[4]](diffhunk://#diff-3c6ca6a06ee8b2e7e1bbe7614deb46dcb6ea7a7f7e4972afc69ec6ba3f275806L17-R17) [[5]](diffhunk://#diff-3c6ca6a06ee8b2e7e1bbe7614deb46dcb6ea7a7f7e4972afc69ec6ba3f275806L44-R44) [[6]](diffhunk://#diff-1a1b66774645babd3039054282a2831832f86787df7d41ef513e6a221577cd57L37-R37) [[7]](diffhunk://#diff-8a9e0c3cdf0fa818e3847faa6564282e952234d18aa1e8500d0565c0b1e66af6L23-R23) [[8]](diffhunk://#diff-8a9e0c3cdf0fa818e3847faa6564282e952234d18aa1e8500d0565c0b1e66af6L143-R143) [[9]](diffhunk://#diff-8a9e0c3cdf0fa818e3847faa6564282e952234d18aa1e8500d0565c0b1e66af6L195-R195)

**Channel access and onboarding:**

* Documentation explicitly notes that the `moderators` channel is now open to Cutie Helpers for improved transparency and training.
* New staff onboarding and Mod on Call instructions have been updated to reference the correct channels and schedules. [[1]](diffhunk://#diff-22760d417a52c66f14bee182587d458d0737a616dd14cb09748b4c725fc5809fL67-R67) [[2]](diffhunk://#diff-7928bfd96161ed25071c9c16e283f7f1994831d5a07df9888f75dc77d55b14beL19-R19) [[3]](diffhunk://#diff-7928bfd96161ed25071c9c16e283f7f1994831d5a07df9888f75dc77d55b14beL41-R53)

These updates ensure all documentation accurately reflects the current Discord server structure, making it easier for staff to find the right channels and follow procedures.