### PR TITLE
Update configuration and documentation: Enable trailing slash in Docu…

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -18,14 +18,3 @@ lolmaxz:
     discord: https://discord.gg/theedenapis
     x: https://x.com/TheEdenApis
     website: https://theedenapis.com
-
-lusaffi:
-  name: Lusaffi
-  title: Discord Community Co-Owner
-  url: https://theedenapis.com
-  image_url: https://cdn.discordapp.com/avatars/797721161504653332/dfd3648b20f6b1164512047e33f2adac.webp?size=512
-  page: true
-  socials:
-    github: https://github.com/LuSaffi
-    x: https://x.com/lusaffi
-    website: https://lusaffi.carrd.co/

--- a/blog/welcome/index.md
+++ b/blog/welcome/index.md
@@ -1,7 +1,7 @@
 ---
 slug: the-eden-apis-origins
 title: The Eden Apis - How It All Began
-authors: [lolmaxz, lusaffi, krenki]
+authors: [lolmaxz, krenki]
 date: 2025-01-24T10:00
 tags: [Eden Official, Autobiography]
 ---

--- a/docs/TestPage.md
+++ b/docs/TestPage.md
@@ -82,7 +82,7 @@ import RoleBadge from "@site/src/components/RoleBadge";
 - **Event Team Heads**: Event Team Head (#f75edb), Head Moderator (#db1cb8), Head of Security (#3fa7ff)
 - **Event Team**: Senior Event Team (#ffc857), Event Host (#a259f7), Event Security (#ff5e5b), Event Team Trial (#3fa7ff)
 - **Staff Roles**: Moderator (#e68027), Helper (#38c8e8)
-- **Staff Members**: lolmaxz, lusaffi, krenki, deldepth, echo1108, s4.ryn, Solii, cdkinetic, verbaldrop, nightmarediztydoo, defovr, cobramaia, vervacious\_ (#00B9ff)
+- **Staff Members**: lolmaxz, krenki, echo1108, s4.ryn, Solii, cdkinetic, verbaldrop, nightmarediztydoo, defovr, cobramaia, vervacious\_ (#00B9ff)
 
 ```jsx title="RoleBadge Usage Code Example:"
 // Custom color (overrides preset)

--- a/docs/general-handbook/staff-roles/staff-positions.md
+++ b/docs/general-handbook/staff-roles/staff-positions.md
@@ -23,7 +23,7 @@ The **Lewd Governors** are the owners and co-owners of the server.
 - Oversee the overall server operations.
 
 :::info
-Currently, <RoleBadge role="lolmaxz" color="#00B9ff" />, <RoleBadge role="lusaffi" color="#00B9ff" /> and <RoleBadge role="krenki" color="#00B9ff" /> serves as Lewd Governors, overseeing the server's operations.
+Currently, <RoleBadge role="lolmaxz" color="#00B9ff" /> and <RoleBadge role="krenki" color="#00B9ff" /> serves as Lewd Governors, overseeing the server's operations.
 :::
 
 ---

--- a/docs/server-staff-handbook/ban-votes/emergency-ban-vote.md
+++ b/docs/server-staff-handbook/ban-votes/emergency-ban-vote.md
@@ -18,7 +18,7 @@ In rare cases where a member poses a serious disruption or safety concern.
 ### Replacement Representatives
 
 - **Maxie** (<RoleBadge role="Lewd Governor" color="#ff6b6b" />): <RoleBadge role="HR" color="#ff6b6b" />
-- **Lulu** (<RoleBadge role="Lewd Governor" color="#ff6b6b" />) or **Krenki** (<RoleBadge role="Lewd Governor" color="#ff6b6b" />): <RoleBadge role="Head Moderator" color="#e68027" /> / <RoleBadge role="Event Manager" color="#f75edb" />
+- **Krenki** (<RoleBadge role="Lewd Governor" color="#ff6b6b" />): <RoleBadge role="Head Moderator" color="#e68027" /> / <RoleBadge role="Event Manager" color="#f75edb" />
 
 ## Guidelines
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   // For Vercel microfrontends, the baseUrl is needed so assets are correctly referenced
   // Vercel will route /staff-handbooks/* to this app, and the app serves with the baseUrl prefix
   baseUrl: "/staff-handbooks/",
-  trailingSlash: false,
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/src/components/RoleBadge.tsx
+++ b/src/components/RoleBadge.tsx
@@ -34,7 +34,6 @@ const roleToColorMap: Record<string, string> = {
   Helper: "#38c8e8",
   // -- Separate Staff Members --
   lolmaxz: "#00B9ff",
-  lusaffi: "#00B9ff",
   krenki: "#00B9ff",
   deldepth: "#00B9ff",
   echo1108: "#00B9ff",

--- a/vercel.json
+++ b/vercel.json
@@ -2,21 +2,11 @@
   "buildCommand": "npm run build",
   "outputDirectory": "build",
   "rewrites": [
-    {
-      "source": "/staff-handbooks/img/(.*)",
-      "destination": "/img/$1"
-    },
-    {
-      "source": "/staff-handbooks/assets/(.*)",
-      "destination": "/assets/$1"
-    },
-    {
-      "source": "/staff-handbooks/(.*)",
-      "destination": "/$1"
-    },
-    {
-      "source": "/staff-handbooks",
-      "destination": "/index.html"
-    }
+    { "source": "/staff-handbooks", "destination": "/index.html" },
+    { "source": "/staff-handbooks/", "destination": "/index.html" },
+
+    { "source": "/staff-handbooks/assets/(.*)", "destination": "/assets/$1" },
+    { "source": "/staff-handbooks/img/(.*)", "destination": "/img/$1" },
+    { "source": "/staff-handbooks/(.*)", "destination": "/$1" }
   ]
 }


### PR DESCRIPTION
…saurus config, streamline Vercel rewrites, and remove references to 'lusaffi' from authors and staff roles across multiple files for consistency.