### PR TITLE
Update staff roles documentation: Remove 'cdkinetic' from Staff Member and updated HR

### DIFF
--- a/docs/TestPage.md
+++ b/docs/TestPage.md
@@ -83,7 +83,7 @@ import RoleBadge from "@site/src/components/RoleBadge";
 - **Event Team Heads**: Event Team Head (#f75edb), Head Moderator (#db1cb8), Head of Security (#3fa7ff)
 - **Event Team**: Senior Event Team (#ffc857), Event Host (#a259f7), Event Security (#ff5e5b), Event Team Trial (#3fa7ff)
 - **Staff Roles**: Moderator (#e68027), Helper (#38c8e8)
-- **Staff Members**: lolmaxz, krenki, s4.ryn, Solii, cdkinetic, verbaldrop, nightmarediztydoo, defovr, zerohour1998, cobramaia, vervacious\_ (#00B9ff)
+- **Staff Members**: lolmaxz, krenki, s4.ryn, Solii, verbaldrop, nightmarediztydoo, defovr, zerohour1998, cobramaia, vervacious\_ (#00B9ff)
 
 ```jsx title="RoleBadge Usage Code Example:"
 // Custom color (overrides preset)

--- a/docs/general-handbook/staff-roles/server-positions/server-roles.md
+++ b/docs/general-handbook/staff-roles/server-positions/server-roles.md
@@ -40,7 +40,7 @@ The person in charge of the **Server Team**, overseeing all actions, moderations
 
 :::note
 The Head Moderator ensures the server runs smoothly and that the moderation team is effective.
-Currently, this position is occupied by <RoleBadge role="Solii" color="#00B9ff" badgeIcon="" /> and <RoleBadge role="cdkinetic" color="#00B9ff" badgeIcon="" />.
+Currently, this position is occupied by <RoleBadge role="Krenki" color="#00B9ff" badgeIcon="" />.
 :::
 
 ---

--- a/docs/general-handbook/staff-roles/staff-positions.md
+++ b/docs/general-handbook/staff-roles/staff-positions.md
@@ -62,7 +62,7 @@ The **Horny Resources** department handles internal staff matters.
 :::info Why an HR?
 HR is essential for maintaining a positive and professional environment among staff members.
 
-Currently, <RoleBadge role="s4.ryn" color="#00B9ff" /> serves as HR member.
+Currently, <RoleBadge role="s4.ryn" color="#00B9ff" />, <RoleBadge role="solii" color="#00B9ff" /> and <RoleBadge role="zerohour1998" color="#00B9ff" /> serves as HR members.
 :::
 
 ---

--- a/docs/server-staff-handbook/onboarding/getting-discord-user-id.md
+++ b/docs/server-staff-handbook/onboarding/getting-discord-user-id.md
@@ -51,8 +51,8 @@ After enabling Developer Mode:
 
 Example:
 
-- **Discord Username**: `Cdkinetic`
-- **Discord User ID**: `184687352394809345`
+- **Discord Username**: `lolmaxz`
+- **Discord User ID**: `229734830932361216`
 
 :::warning
 Ensure you are copying the correct ID, especially when dealing with reports or moderation actions.

--- a/src/components/RoleBadge.tsx
+++ b/src/components/RoleBadge.tsx
@@ -35,10 +35,8 @@ const roleToColorMap: Record<string, string> = {
   // -- Separate Staff Members --
   lolmaxz: "#00B9ff",
   krenki: "#00B9ff",
-  deldepth: "#00B9ff",
   "s4.ryn": "#00B9ff",
   Solii: "#00B9ff",
-  cdkinetic: "#00B9ff",
   verbaldrop: "#00B9ff",
   nightmarediztydoo: "#00B9ff",
   defovr: "#00B9ff",


### PR DESCRIPTION
Update staff roles documentation: Remove 'cdkinetic' from Staff Members, add 'solii' and 'zerohour1998' as HR members, and update Head Moderator position to reflect 'krenki' as the current occupant. Adjust Discord user ID example to 'lolmaxz'.